### PR TITLE
Compress recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ windows:
 
 macos:
 	go build -o artifacts/ThrowPro.app/Contents/MacOS/ThrowPro ./gui
-	cd artifacts && zip throwpro_v07_mac.zip ThrowPro.app
+	cd artifacts && zip -r throwpro_v07_mac.zip ThrowPro.app
 	rm -rf artifacts/ThrowPro.app
 	
 lambda:


### PR DESCRIPTION
Without the `-r`, zip does not recursively compress the artifact, and thus results in a very small empty zip file. Adding the `-r` to ensure the artifact binary gets included. Note: Website zip is currently broken as well.